### PR TITLE
Define determine_locale() only if not already defined

### DIFF
--- a/acf-pro-stubs.php
+++ b/acf-pro-stubs.php
@@ -16209,8 +16209,10 @@ function acf_write_json_field_group($field_group)
 function acf_delete_json_field_group($key)
 {
 }
-function determine_locale()
-{
+if (!function_exists('determine_locale')) {
+    function determine_locale()
+    {
+    }
 }
 /*
  * acf_get_locale


### PR DESCRIPTION
Using this library alongside `php-stubs/wordpress-stubs` will break PHPStan.

composer.json (partially) (`php-stubs/wordpress-stubs` is a dependency of `php-stubs/woocommerce-stubs`)

```
  "scripts": {
    "phpstan": "phpstan analyze"
  },
  "require-dev": {
    "paulthewalton/acf-pro-stubs": "^5.8",
    "php-stubs/woocommerce-stubs": "^3.8",
    "szepeviktor/phpstan-wordpress": "^0.5.0"
  }
```

phpstan.neon.dist (partially)

```
includes:
    # @see https://github.com/phpstan/phpstan/blob/master/conf/bleedingEdge.neon
    - phar://phpstan.phar/conf/bleedingEdge.neon
    # Include this extension
    - vendor/szepeviktor/phpstan-wordpress/extension.neon
parameters:
    level: max
    inferPrivatePropertyTypeFromConstructor: true
    autoload_files:
      - %currentWorkingDirectory%/vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
      - %currentWorkingDirectory%/vendor/paulthewalton/acf-pro-stubs/acf-pro-stubs.php
```

Running `phpstan analyze` will then result in

```
➜ composer phpstan
> phpstan analyze
Note: Using configuration file .../phpstan.neon.dist.
PHP Fatal error:  Cannot redeclare determine_locale() (previously declared in .../vendor/php-stubs/wordpress-stubs/wordpress-stubs.php:89692) in .../vendor/paulthewalton/acf-pro-stubs/acf-pro-stubs.php on line 16212
Fatal error: Cannot redeclare determine_locale() (previously declared in .../vendor/php-stubs/wordpress-stubs/wordpress-stubs.php:89692) in .../vendor/paulthewalton/acf-pro-stubs/acf-pro-stubs.php on line 16212
```

This PR will solve this issue.