### PR TITLE
Run tests on current PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ cache:
 php:
   - '7.1'
   - '7.2'
+  - '7.3'
+  - '7.4'
   - nightly
 
 matrix:


### PR DESCRIPTION
7.2 and below are EOL-ed