### PR TITLE
Shorten package description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "paulthewalton/acf-pro-stubs",
     "version": "5.8.9.1",
     "type": "library",
-    "description": "ACF Pro stubs! Based on giacocorsiglia/wordpress-stubs. Advanced Custom Fields function, class, and global variable declaration stubs for easier static analysis.",
+    "description": "Advanced Custom Fields Pro function, class and global variable declaration stubs for easier static analysis.",
     "keywords": [
         "wordpress",
         "static analysis",


### PR DESCRIPTION
Sometime it appears on the screen and looks nice if it fits on 1 line.