### PR TITLE
xdebug is not available on PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 before_install:
   - |
     if [ "$(phpenv version-name)" != 8.0 ]; then
+      echo -n "PHP version="; phpenv version-name
       phpenv config-rm xdebug.ini
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 
 before_install:
   - |
-    if [ "$(phpenv version-name)" != 7.4 ]; then
+    if [ "$(phpenv version-name)" != 8.0 ]; then
       phpenv config-rm xdebug.ini
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ matrix:
 
 before_install:
   - |
-    if [ "$(phpenv version-name)" != 8.0 ]; then
-      echo -n "PHP version="; phpenv version-name
+    if [ "$(phpenv version-name)" != nightly ]; then
       phpenv config-rm xdebug.ini
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ matrix:
     - php: nightly
 
 before_install:
-  - phpenv config-rm xdebug.ini
+  - |
+    if [ "$(phpenv version-name)" != 7.4 ]; then
+      phpenv config-rm xdebug.ini
+    fi
 
 install:
   - composer validate --strict


### PR DESCRIPTION
See https://github.com/php-stubs/wordpress-stubs/blob/baab62405f6a6ac9b25ed3fe6df371d090f9bc0c/.travis.yml#L18-L21